### PR TITLE
FST2 - Ansible is updated to latest versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,7 @@ FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
 
 AWS_REGION ?= us-west-1
 
-ARM64_INSTANCE_TYPE ?= m7g.xlarge
-AMD64_INSTANCE_TYPE ?= m7a.xlarge
-WIN64_INSTANCE_TYPE ?= m7i.xlarge
+AMD64_INSTANCE_TYPE ?= m6a.xlarge
 
 BUILDKITE_BUILD_NUMBER ?= none
 BUILDKITE_PIPELINE_DEFAULT_BRANCH ?= main
@@ -111,17 +109,6 @@ build/fix-perms-linux-amd64: $(FIXPERMS_FILES)
 		--rm \
 		golang:$(GO_VERSION) \
 			go build -v -buildvcs=false -o "build/fix-perms-linux-amd64" ./internal/fixperms
-
-build/fix-perms-linux-arm64: $(FIXPERMS_FILES)
-	docker run \
-		-e CGO_ENABLED=0 \
-		-e GOOS=linux \
-		-e GOARCH=arm64 \
-		-v "$(PWD):/src" \
-		-w /src \
-		--rm \
-		golang:$(GO_VERSION) \
-			go build -v -buildvcs=false -o "build/fix-perms-linux-arm64" ./internal/fixperms
 
 # -----------------------------------------
 # Cloudformation helpers

--- a/packer/linux/scripts/install-packform.sh
+++ b/packer/linux/scripts/install-packform.sh
@@ -2,13 +2,13 @@
 set -eu -o pipefail
 
 echo "Creating Ansible venv..."
-sudo /usr/local/bin/python3.10 -m venv /srv/venv/ansible
+sudo python3.11 -m venv /srv/venv/ansible
 sudo chmod -R +rw /srv/venv/ansible
 sudo chown -R ec2-user: /srv/venv/ansible
 
 echo "Priming venv..."
 source /srv/venv/ansible/bin/activate
-pip3 install ansible==7.2.0 boto3 docker requests
+pip3 install ansible==9.1.0 boto3 docker==6.0.1 requests
 deactivate
 
 # TODO: pre-install Docker build images

--- a/packer/linux/scripts/upgrade-python.sh
+++ b/packer/linux/scripts/upgrade-python.sh
@@ -1,12 +1,3 @@
 #!/usr/bin/env bash
 
-sudo yum update -y
-sudo yum groupinstall "Development Tools" -y
-sudo yum erase openssl-devel -y
-sudo yum install openssl11 openssl11-devel libffi-devel bzip2-devel wget -y
-sudo wget https://www.python.org/ftp/python/3.10.10/Python-3.10.10.tgz
-sudo tar xzf Python-3.10.10.tgz && cd Python-3.10.10
-sudo ./configure --enable-optimizations
-nproc && make -j $(nproc)
-sudo make altinstall
-python3.10 --version
+sudo dnf install python3.11 -y


### PR DESCRIPTION
Trello card: https://trello.com/c/psd9Ly6R/5482-fst2-ansible-is-updated-to-latest-versions

Related PRs:
  - https://github.com/packform/pp-ansible/pull/351

---

As Packform
I want my CI pipeline to be patched regularly
So that it remains safe and secure

## Acceptance Criteria

As a Packform engineer
I should see the following card template is updated
And it shouldexplain how to update and test ansible in buildkite agent
And I should see it updated to the latest version 

Template:
https://trello.com/c/LSws4zaV/1648-mnt-repeat-jenkins-and-ansible-are-updated-to-latest-versions