### PR TITLE
S25 - Buildkite agents and Ansible are updated to latest versions

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -50,7 +50,6 @@ data "amazon-ami" "al2023" {
 
 source "amazon-ebs" "elastic-ci-stack-ami" {
   ami_description                           = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
-  ami_groups                                = ["all"]
   ami_name                                  = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region

--- a/packer/linux/scripts/install-packform.sh
+++ b/packer/linux/scripts/install-packform.sh
@@ -8,7 +8,7 @@ sudo chown -R ec2-user: /srv/venv/ansible
 
 echo "Priming venv..."
 source /srv/venv/ansible/bin/activate
-pip3 install ansible==9.1.0 boto3 docker==6.0.1 requests
+pip3 install ansible==11.6.0 boto3 docker==6.0.1 requests
 deactivate
 
 # TODO: pre-install Docker build images


### PR DESCRIPTION
Trello card: https://trello.com/c/MO05x7k3/6824-s25-buildkite-agents-and-ansible-are-updated-to-latest-versions

Related PRs:
  - https://github.com/packform/pp-ansible/pull/536

---

As Packform
I want my CI pipeline to be patched regularly
So that it remains safe and secure

## Acceptance Criteria

As a Packform engineer
When I open the Buildkite Infrastructure documentation in Notion
Then I should follow the instructions to Update the Buildkite AMI
And I should see ansible is updated to the latest version

When I open the `pp-ansible` repository
Then I should see ansible is updated to the latest version

After updating the Buildkite AMI
When I run any Packfrom buildkite pipeline
Then I should see it run successfully as usual

## Document

[(1) Buildkite Infrastructure (notion.so)](https://www.notion.so/packform/Buildkite-Infrastructure-de7249405c4547b3be047577f34ae1ab "‌")
